### PR TITLE
Do not run CI for PRs where both branches are from the same repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-test:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
When a pull request is created by comparing branches that are on the same repo, duplicate CI runs would be created: one for the branch push, and one for the pull request.
This PR prevents that, whilst preserving the ability to run the CI for each branch push to a fork, and for each pull request originating from a fork.